### PR TITLE
Change some meta feed messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ as [bendy-butt] bencode dictionaries):
 ```
 { "type" => "metafeed/add", "feedpurpose" => "main", "subfeed" => (BFE feed ID) }
 { "type" => "metafeed/add", "feedpurpose" => "indexes", "subfeed" => (BFE Bendy Butt feed ID) }
-{ "type" => "metafeed/add", "feedpurpose" => "index", "subfeed" => (BFE feed ID) }
+{ "type" => "metafeed/add", "feedpurpose" => "audits", "subfeed" => (BFE feed ID) }
 { "type" => "metafeed/add", "feedpurpose" => "trust", "subfeed" => (BFE Bendy Butt feed ID) }
-{ "type" => "metafeed/add", "feedpurpose" => "fusionidentity", "subfeed" => (BFE Fusion Identity feed ID) }
+{ "type" => "metafeed/add", "feedpurpose" => "fusionidentities", "subfeed" => (BFE feed ID) }
 ```
 
 ## Indexes


### PR DESCRIPTION
When I reviewed #6 I skimmed over the json -> bencode changes because I thought it was only that. Seems like two other things snug in :)

I would like to keep the audits name and the fusion identities to signal that its a feed where the messages contribute to one or more fusion identities over time (if you loose a device you have to tombstone and create a new one).