### PR TITLE
suggest to also add the indexed sequence number to an index message

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For the definition of the query language see [ssb-ql-0].
 
 Index message format in a classic SSB feed:
 
-```json
+```js
 {
   type: 'metafeed/index',
   indexed: {

--- a/README.md
+++ b/README.md
@@ -55,9 +55,18 @@ For the definition of the query language see [ssb-ql-0].
 
 Index message format in a classic SSB feed:
 
+```json
+{
+  type: 'metafeed/index',
+  indexed: {
+    key: '%msgkey',
+    sequence: 42
+  }
+}
 ```
-{ type: 'metafeed/index', indexed: '%msgkey' }
-```
+
+The `indexed.sequence` might seem redundant but it might be much cheaper
+for an implementation to resolve `author@sequence` and checking the hash of the message then keeping a total `hash => message` index.
 
 # Fusion identity
 


### PR DESCRIPTION
from the diff:

> The `indexed.sequence` might seem redundant but it might be much cheaper
for an implementation to resolve `author@sequence` and checking the hash of the message then keeping a total `hash => message` index.
